### PR TITLE
Give meaningful names and comments to the signals in control_unit

### DIFF
--- a/sm83-cpu-core/SGB-CPU_01_sm83_core_40x.svg
+++ b/sm83-cpu-core/SGB-CPU_01_sm83_core_40x.svg
@@ -925,68 +925,68 @@
        id="g412014"
        style="display:inline"
        transform="translate(0,12.5)"
-       inkscape:label="nIRQ_TRIGGER">
+       inkscape:label="nIRQ_REQ">
       <path
          style="marker-start:url(#Square)"
          d="m 7338.5165,6524.5049 -2.5018,-2091.2097 h -46.4224 l -3.7874,6.56 h -200.5122 v -18.0691 h -26.5142"
          id="path411193"
          sodipodi:nodetypes="ccccccc"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7236.9809,4513.0432 h 99.1023"
          id="path412020"
          style="marker-start:url(#Square)"
          sodipodi:nodetypes="cc"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7256.2825,4910.8023 h 80.1424"
          id="path412022"
          style="marker-start:url(#Square)"
          sodipodi:nodetypes="cc"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7275.702,5308.2852 h 61.0643"
          id="path412024"
          style="marker-start:url(#Square)"
          sodipodi:nodetypes="cc"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7294.9501,5705.8867 h 42.1578"
          id="path412026"
          sodipodi:nodetypes="cc"
          style="marker-start:url(#Square)"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7313.0965,6115.5574 h 24.3633"
          id="path412028"
          style="marker-start:url(#Square)"
          sodipodi:nodetypes="cc"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7338.5165,7105.8318 h 224.4547 v -26.7879 h 27.7057"
          id="path412780"
          sodipodi:nodetypes="cccc"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7514.4222,7105.8318 v -19.42"
          id="path412782"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="M 7338.5165,7345.3065 V 6935.2639"
          id="path413538"
          sodipodi:nodetypes="cc"
          style="marker-start:url(#Square)"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          d="m 7338.5165,6935.2639 v -410.759"
          id="path413544"
          style="marker-start:url(#Square)"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
       <path
          style="marker-start:url(#Square)"
          d="M 7579.7404,4661.0531 H 7336.2872"
          id="path413818"
-         inkscape:label="nIRQ_TRIGGER" />
+         inkscape:label="nIRQ_REQ" />
     </g>
     <g
        id="g83404"
@@ -995,172 +995,172 @@
          style="display:inline;marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="m 7674.8673,7555.7988 v -68.6845"
          id="path591171"
-         inkscape:label="nINTR_TRIGGER_0_xxxx_xxxx" />
+         inkscape:label="nINTR_WAKE_0_xxxx_xxxx" />
       <path
          style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="M 7674.3673,7461.555 V 7075.7876"
          id="path585659"
-         inkscape:label="nINTR_TRIGGER_0_0xxx_xxxx" />
+         inkscape:label="nINTR_WAKE_0_0xxx_xxxx" />
       <path
          style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="M 7673.8673,7051.411 V 6668.4765"
          id="path585657"
-         inkscape:label="nINTR_TRIGGER_0_00xx_xxxx" />
+         inkscape:label="nINTR_WAKE_0_00xx_xxxx" />
       <path
          style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="M 7673.3673,6641.328 V 6257.8755"
          id="path585655"
-         inkscape:label="nINTR_TRIGGER_0_000x_xxxx" />
+         inkscape:label="nINTR_WAKE_0_000x_xxxx" />
       <path
          style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="M 7672.8673,6231.8044 V 5848.1498"
          id="path585653"
-         inkscape:label="nINTR_TRIGGER_0_0000_xxxx" />
+         inkscape:label="nINTR_WAKE_0_0000_xxxx" />
       <path
          style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="M 7672.3673,5822.2074 V 5450.176"
          id="path585651"
-         inkscape:label="nINTR_TRIGGER_0_0000_0xxx" />
+         inkscape:label="nINTR_WAKE_0_0000_0xxx" />
       <path
          style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="m 7672.8673,5425.0125 v -372.483"
          id="path585649"
-         inkscape:label="nINTR_TRIGGER_0_0000_00xx" />
+         inkscape:label="nINTR_WAKE_0_0000_00xx" />
       <path
          style="display:inline;marker-start:url(#Square);marker-end:url(#Arrow1L)"
          d="M 7672.3673,5027.8653 V 4655.0245"
          id="path585647"
-         inkscape:label="nINTR_TRIGGER_0_0000_000x" />
+         inkscape:label="nINTR_WAKE_0_0000_000x" />
       <g
          id="g580805"
          style="display:inline"
-         inkscape:label="nINTR_TRIGGER">
+         inkscape:label="nINTR_WAKE">
         <path
            d="m 7670.4923,4630.4474 v -311.2232 h -297.7674 v 72.515 h -158.8697 v 23.6471 h -66.4713 v -18.4365 h -26.0489"
            id="path580802"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="M 7372.7249,4630.8028 V 4391.7392"
            id="path580807"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="m 7374.1675,5028.8827 -1.4426,-398.0799"
            id="path580809"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            style="marker-start:url(#Square)"
            d="M 7374.1675,5426.7545 V 5028.8827"
            id="path585635"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            style="marker-start:url(#Square)"
            d="M 7374.1675,5823.7526 V 5426.7545"
            id="path580811"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="M 7374.1675,6233.0654 V 5823.7526"
            id="path580813"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="m 7374.1675,6642.9184 v -409.853"
            id="path580815"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="M 7374.1675,7051.6966 V 6642.9184"
            id="path580817"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="m 7374.9353,7461.3605 -0.7678,-409.6639"
            id="path580819"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
         <path
            d="M 7374.9353,7565.8768 V 7461.3605"
            id="path580821"
            style="marker-start:url(#Square)"
-           inkscape:label="nINTR_TRIGGER" />
+           inkscape:label="nINTR_WAKE" />
       </g>
     </g>
     <g
        id="g640878"
-       inkscape:label="nNMI_TRIGGER"
+       inkscape:label="nNMI_DISPATCH"
        style="display:inline">
       <path
          d="m 7103.3119,4428.3115 h 49.3283 v 10.7185 h 92.8734"
          id="path640875"
          style="marker-start:url(#Square)"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7245.5136,4439.03 h 29.0118 l 6.6402,-11.5011 h 72.6642 l 2.9853,3119.111 h 139.7864 v -18.0201 h 105.4328 v -20.5721"
          id="path640880"
          style="marker-start:url(#Square)"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7461.0811,7546.6399 v 21.3435"
          id="path640882"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7356.6573,7381.8021 h -5.9366 v 27.613"
          id="path640884"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7356.2759,6983.2882 h -8.2518 v 26.6704"
          id="path640886"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7355.8622,6550.9887 h -7.3166 v 26.9039"
          id="path640888"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7355.4691,6140.2653 h -7.2634 v 26.2655"
          id="path640890"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7355.0778,5731.4765 h -9.2713 v 26.4833"
          id="path640892"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7354.6966,5333.2301 h -7.7738 v 27.2246"
          id="path640894"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7354.3169,4936.4114 h -6.6824 v 26.6518"
          id="path640896"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
       <path
          d="m 7353.9363,4538.7704 h -8.6345 v 28.9322"
          id="path640898"
-         inkscape:label="nNMI_TRIGGER" />
+         inkscape:label="nNMI_DISPATCH" />
     </g>
     <g
        id="g663723"
-       inkscape:label="NMI_TRIGGER"
+       inkscape:label="NMI_DISPATCH"
        style="display:inline">
       <path
          d="m 7582.8537,7518.2065 h -18.344 v 40.2168 h -49.1035 v 14.0945 h -25.6134 v 43.0699 h -47.4938 v -39.1164 h -55.886 v -20.2736"
          id="path663720"
          style="marker-start:url(#Square)"
-         inkscape:label="NMI_TRIGGER" />
+         inkscape:label="NMI_DISPATCH" />
       <path
          d="m 7485.1792,7558.4233 h 30.227"
          id="path663725"
          style="marker-start:url(#Square)"
          sodipodi:nodetypes="cc"
-         inkscape:label="NMI_TRIGGER" />
+         inkscape:label="NMI_DISPATCH" />
       <path
          d="m 7564.5097,7540.8553 h 91.6059 v 27.0206"
          id="path663727"
-         inkscape:label="NMI_TRIGGER" />
+         inkscape:label="NMI_DISPATCH" />
       <path
          d="m 7600.6406,7540.8553 v 21.7201"
          id="path663729"
-         inkscape:label="NMI_TRIGGER" />
+         inkscape:label="NMI_DISPATCH" />
     </g>
     <g
        id="g775101"
@@ -1659,12 +1659,12 @@
          d="M 3603.54,302.524 7221.4,297.565"
          id="path64359"
          style="opacity:1"
-         inkscape:label="INTR_DISPATCH" />
+         inkscape:label="INTR" />
       <path
          d="M 3603.54,285.404 7221.4,279.827"
          id="path64357"
          style="opacity:1"
-         inkscape:label="nINTR_DISPATCH" />
+         inkscape:label="nINTR" />
     </g>
     <g
        id="g860"
@@ -12161,7 +12161,7 @@
          d="m 7893.334,439.86108 v 21.4298"
          id="path26828"
          style="display:inline;marker-start:url(#Square);marker-end:url(#Arrow1L)"
-         inkscape:label="INTR_REQ" />
+         inkscape:label="INTR_WAKE_SYNC" />
       <path
          d="M 8319.5427,1042.3386 V 749.54114 h -34.4441"
          id="path28572"
@@ -20292,23 +20292,23 @@
          id="path26264"
          style="display:inline;marker-start:url(#Square);marker-end:url(#Arrow1L)"
          sodipodi:nodetypes="ccccccccccccccccccccc"
-         inkscape:label="INTR_TRIGGER" />
+         inkscape:label="INTR_WAKE" />
       <g
          id="g600799"
-         inkscape:label="IRQ_TRIGGER"
+         inkscape:label="IRQ_REQ"
          style="display:inline">
         <path
            d="m 7301.1681,4445.9368 h -38.7342 v -47.7023 h 7.2519 v -105.153 h -134.1579 v -242.4522 h -37.2274 v -92.6529 h 53.1781 v -37.2415 h 18.0652 v -35.5409 h 73.1895 v -60.061 h 62.1666 v -14.2498 h 128.6175 v -110.1075 h 316.1345 v -37.4062 h 328.6249 v 44.2963 -1195.3746 h 52.4673"
            id="path44469"
            style="display:inline;marker-start:url(#Square);marker-end:url(#Arrow1L)"
            sodipodi:nodetypes="ccccccccccccccccccccccccc"
-           inkscape:label="IRQ_TRIGGER" />
+           inkscape:label="IRQ_REQ" />
         <path
            d="m 7071.6067,4433.2977 h 26.8888 v 12.6391 h 163.9384"
            id="path600821"
            style="marker-start:url(#Square)"
            sodipodi:nodetypes="cccc"
-           inkscape:label="IRQ_TRIGGER" />
+           inkscape:label="IRQ_REQ" />
       </g>
     </g>
     <g
@@ -20413,7 +20413,7 @@
       <path
          d="m 7514.5815,304.23944 h -21.3299"
          id="path106594"
-         inkscape:label="nINTR_DISPATCH"
+         inkscape:label="nINTR"
          sodipodi:nodetypes="cc"
          style="display:inline;marker-start:url(#Square);marker-end:url(#Arrow1L)" />
       <g
@@ -20444,22 +20444,22 @@
       </g>
       <g
          id="g148091"
-         inkscape:label="NMI_TRIGGER"
+         inkscape:label="NMI_DISPATCH"
          style="display:inline">
         <path
            d="m 8186.4416,1264.1945 v -6.3925 h -109.8868 v 42.5017 h -109.6979"
            id="path148063"
            style="marker-start:url(#Square);marker-end:url(#Arrow1L)"
-           inkscape:label="NMI_TRIGGER" />
+           inkscape:label="NMI_DISPATCH" />
         <path
            d="m 8186.4416,1257.802 h 134.0289 l 2.6152,2606.485 -1262.3072,1.2632 v 202.7897 h 57.0383 l -3.2507,238.8889 h 118.2755 v 111.4441 h 24.1796"
            id="path67809"
-           inkscape:label="NMI_TRIGGER"
+           inkscape:label="NMI_DISPATCH"
            sodipodi:nodetypes="cccccccccc" />
         <path
            d="m 7232.8416,4418.6729 v 12.0021 h -117.638 v -29.727 h -25.0137"
            id="path596036"
-           inkscape:label="NMI_TRIGGER" />
+           inkscape:label="NMI_DISPATCH" />
       </g>
     </g>
     <g

--- a/sm83-cpu-core/hdl/.gitignore
+++ b/sm83-cpu-core/hdl/.gitignore
@@ -6,3 +6,7 @@ __pycache__/
 /test.gb
 /vunit_out/
 /vhdl_ls.toml
+
+*.vcd
+*.gtkw
+*.ghw

--- a/sm83-cpu-core/hdl/control_unit.vhd
+++ b/sm83-cpu-core/hdl/control_unit.vhd
@@ -25,14 +25,14 @@ entity control_unit is
     reset_ack: in std_ulogic;
     decoder: in decoder_type;
     cc_match: in std_ulogic;
-    intr_trigger: in std_ulogic;
-    irq_trigger: in std_ulogic;
+    intr_wake: in std_ulogic;
+    irq_req: in std_ulogic;
     ir_reg: in std_ulogic_vector(7 downto 0);
     state: out std_ulogic_vector(2 downto 0);
     cb_mode: out std_ulogic;
-    intr_dispatch: out std_ulogic;
+    intr: out std_ulogic;
     data_lsb: out std_ulogic;
-    nmi_trigger: out std_ulogic;
+    nmi_dispatch: out std_ulogic;
     rd: out std_ulogic;
     memrq: out std_ulogic;
     cpuclk_en: out std_ulogic;
@@ -46,7 +46,7 @@ architecture asic of control_unit is
   signal reset_op_ext: std_ulogic := '0';
   signal op_stop: std_ulogic;
   signal reset_any: std_ulogic;
-  signal halt_req, stop_req, intr_req: std_ulogic;
+  signal halt_req, stop_req, intr_wake_sync: std_ulogic;
   signal cpuclk_shdn, sysclk_shdn: std_ulogic;
 
   signal xurg: std_ulogic;
@@ -75,10 +75,10 @@ begin
   -- ZBJV
   sysclk_en <= not sysclk_shdn;
 
-  -- ==== decoder intr_dispatch flag
+  -- ==== decoder intr flag
 
   -- XYGB
-  intr_dispatch <= zacw or reset_op_int or reset_op_ext;
+  intr <= zacw or reset_op_int or reset_op_ext;
 
   -- ==== decoder cb_mode flag
 
@@ -141,11 +141,11 @@ begin
   yoii_inst: entity work.dff
   port map (
     clk => mclk_pulse,
-    d => intr_trigger,
-    q => intr_req
+    d => intr_wake,
+    q => intr_wake_sync
   );
 
-  ykua <= not ((intr_req or yolu) and not reset_any);
+  ykua <= not ((intr_wake_sync or yolu) and not reset_any);
 
   yolu <= zorp nor (not zaza);
 
@@ -168,7 +168,7 @@ begin
   -- YCNF
   reset_op_int <= cpuclk_shdn or reset_sync or reset_op_ext;
 
-  yneu <= not ((decoder.int_s110 and nmi_trigger) or reset_sync);
+  yneu <= not ((decoder.int_s110 and nmi_dispatch) or reset_sync);
 
   yepj <= not nmi;
 
@@ -229,7 +229,7 @@ begin
   port map (
     clk => mclk_pulse,
     d => zloz,
-    q => nmi_trigger
+    q => nmi_dispatch
   );
 
   zloz_inst: entity work.srlatch
@@ -266,7 +266,7 @@ begin
 
   zowa <= decoder.int_s110 nor reset_sync;
 
-  zaoc <= xogs nand irq_trigger;
+  zaoc <= xogs nand irq_req;
 
   zzom <= (not ir_reg(3)) nand decoder.op_di_ei_s0xx; -- includes ZEVO
 

--- a/sm83-cpu-core/hdl/cpu_core.vhd
+++ b/sm83-cpu-core/hdl/cpu_core.vhd
@@ -60,15 +60,15 @@ architecture asic of cpu_core is
   signal flags: cpu_flags;
   signal carry: std_ulogic;
 
-  signal intr_dispatch: std_ulogic;
+  signal intr: std_ulogic;
   signal cb_mode: std_ulogic;
   signal state: std_ulogic_vector(2 downto 0);
   signal data_lsb: std_ulogic;
 
-  signal nmi_trigger: std_ulogic;
+  signal nmi_dispatch: std_ulogic;
   signal intr_addr: std_ulogic_vector(7 downto 3);
-  signal intr_trigger: std_ulogic;
-  signal irq_trigger: std_ulogic;
+  signal intr_wake: std_ulogic;
+  signal irq_req: std_ulogic;
 begin
   io_cell_gen: for i in 0 to 7 generate
     io_cell_inst: entity work.io_cell
@@ -87,7 +87,7 @@ begin
     clk => clk,
     phi => phi,
     writeback => writeback,
-    intr_dispatch => intr_dispatch,
+    intr => intr,
     cb_mode => cb_mode,
     ir_reg => ir_reg,
     state => state,
@@ -175,14 +175,14 @@ begin
     reset_ack => reset_ack,
     decoder => decoder,
     cc_match => cc_match,
-    intr_trigger => intr_trigger,
-    irq_trigger => irq_trigger,
+    intr_wake => intr_wake,
+    irq_req => irq_req,
     ir_reg => ir_reg,
     state => state,
     cb_mode => cb_mode,
-    intr_dispatch => intr_dispatch,
+    intr => intr,
     data_lsb => data_lsb,
-    nmi_trigger => nmi_trigger,
+    nmi_dispatch => nmi_dispatch,
     rd => rd,
     memrq => memrq,
     cpuclk_en => cpuclk_en,
@@ -199,11 +199,11 @@ begin
     wr => wr,
     rd => rd,
     irq => irq,
-    nmi_trigger => nmi_trigger,
+    nmi_dispatch => nmi_dispatch,
     int_s110 => decoder.int_s110,
     intr_addr => intr_addr,
+    intr_wake => intr_wake,
     irq_ack => irq_ack,
-    intr_trigger => intr_trigger,
-    irq_trigger => irq_trigger
+    irq_req => irq_req
   );
 end architecture;

--- a/sm83-cpu-core/hdl/decoder.vhd
+++ b/sm83-cpu-core/hdl/decoder.vhd
@@ -12,7 +12,7 @@ entity decoder is
     clk: in std_ulogic;
     phi: in std_ulogic;
     writeback: in std_ulogic;
-    intr_dispatch: in std_ulogic;
+    intr: in std_ulogic;
     cb_mode: in std_ulogic;
     ir_reg: in std_ulogic_vector(7 downto 0);
     state: in std_ulogic_vector(2 downto 0);
@@ -29,7 +29,7 @@ begin
   stage1_inst: entity work.decoder_stage1
   port map (
     clk => clk,
-    intr_dispatch => intr_dispatch,
+    intr => intr,
     cb_mode => cb_mode,
     ir_reg => ir_reg,
     state => state,

--- a/sm83-cpu-core/hdl/decoder_stage1.vhd
+++ b/sm83-cpu-core/hdl/decoder_stage1.vhd
@@ -10,7 +10,7 @@ use work.sm83_decoder.all;
 entity decoder_stage1 is
   port (
     clk: in std_ulogic;
-    intr_dispatch: in std_ulogic;
+    intr: in std_ulogic;
     cb_mode: in std_ulogic;
     ir_reg: in std_ulogic_vector(7 downto 0);
     state: in std_ulogic_vector(2 downto 0);
@@ -26,7 +26,7 @@ begin
   col_1_to_3: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 5) ?= "111";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 5) ?= "111";
     outputs.op_ld_nn_a_s010 <= t and ir_reg(4 downto 0) ?= "01010" and state ?= "010";
     outputs.op_ld_a_nn_s010 <= t and ir_reg(4 downto 0) ?= "11010" and state ?= "010";
     outputs.op_ld_a_nn_s011 <= t and ir_reg(4 downto 0) ?= "11010" and state ?= "011";
@@ -35,7 +35,7 @@ begin
   col_4: process(all)
     variable t, l, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode;
+    t := clk and not intr and not cb_mode;
     l := t and ir_reg ?= "10------";
     r := t and ir_reg ?= "11---110";
     outputs.op_alu8 <= (l or r) and state ?= "---";
@@ -44,30 +44,30 @@ begin
   col_5_to_6: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 4) ?= "110-";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 4) ?= "110-";
     outputs.op_jp_cc_sx01 <= t and ir_reg(3 downto 0) ?= "-010" and state ?= "-01";
     outputs.op_call_cc_sx01 <= t and ir_reg(3 downto 0) ?= "-100" and state ?= "-01";
   end process;
 
   col_7: process(all)
   begin
-    outputs.op_ret_cc_sx00 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "110--000" and state ?= "-00";
+    outputs.op_ret_cc_sx00 <= clk and not intr and not cb_mode and ir_reg ?= "110--000" and state ?= "-00";
   end process;
 
   col_8: process(all)
   begin
-    outputs.op_jr_cc_sx00 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "001--000" and state ?= "-00";
+    outputs.op_jr_cc_sx00 <= clk and not intr and not cb_mode and ir_reg ?= "001--000" and state ?= "-00";
   end process;
 
   col_9: process(all)
   begin
-    outputs.op_ldh_a_x <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "111100-0" and state ?= "---";
+    outputs.op_ldh_a_x <= clk and not intr and not cb_mode and ir_reg ?= "111100-0" and state ?= "---";
   end process;
 
   col_10_to_14: process(all)
     variable t, l, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 5) ?= "110";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 5) ?= "110";
     l := t and ir_reg(4 downto 0) ?= "0110-";
     r := t and ir_reg(4 downto 0) ?= "--100";
     outputs.op_call_any_s000 <= (l or r) and state ?= "000";
@@ -80,7 +80,7 @@ begin
   col_15_to_17: process(all)
     variable t, l, r1, r2, r3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "00";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "00";
     l := t and ir_reg(5 downto 0) ?= "---110";
     outputs.op_ld_x_n <= l and state ?= "---";
     outputs.op_ld_x_n_sx00 <= l and state ?= "-00";
@@ -92,18 +92,18 @@ begin
 
   col_18: process(all)
   begin
-    outputs.op_s110 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "--------" and state ?= "110";
+    outputs.op_s110 <= clk and not intr and not cb_mode and ir_reg ?= "--------" and state ?= "110";
   end process;
 
   col_19: process(all)
   begin
-    outputs.op_s111 <= clk and intr_dispatch ?= '-' and cb_mode ?= '0' and ir_reg ?= "--------" and state ?= "111";
+    outputs.op_s111 <= clk and intr ?= '-' and cb_mode ?= '0' and ir_reg ?= "--------" and state ?= "111";
   end process;
 
   col_20_to_21: process(all)
     variable t, l, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "00";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "00";
     l := t and ir_reg(5 downto 0) ?= "1--000";
     r := t and ir_reg(5 downto 0) ?= "011000";
     outputs.op_jr_any_sx01 <= (l or r) and state ?= "-01";
@@ -112,18 +112,18 @@ begin
 
   col_22: process(all)
   begin
-    outputs.op_add_sp_e_s010 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11101000" and state ?= "010";
+    outputs.op_add_sp_e_s010 <= clk and not intr and not cb_mode and ir_reg ?= "11101000" and state ?= "010";
   end process;
 
   col_23: process(all)
   begin
-    outputs.op_ld_hl_sp_sx10 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11111000" and state ?= "-10";
+    outputs.op_ld_hl_sp_sx10 <= clk and not intr and not cb_mode and ir_reg ?= "11111000" and state ?= "-10";
   end process;
 
   col_24_to_25: process(all)
     variable t, l1, l2, l3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and cb_mode and ir_reg(7 downto 3) ?= "10---";
+    t := clk and not intr and cb_mode and ir_reg(7 downto 3) ?= "10---";
     l1 := t and ir_reg(2 downto 0) ?= "0--";
     l2 := t and ir_reg(2 downto 0) ?= "-0-";
     l3 := t and ir_reg(2 downto 0) ?= "--1";
@@ -133,23 +133,23 @@ begin
 
   col_26: process(all)
   begin
-    outputs.op_rotate_a <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "000--111" and state ?= "---";
+    outputs.op_rotate_a <= clk and not intr and not cb_mode and ir_reg ?= "000--111" and state ?= "---";
   end process;
 
   col_27: process(all)
   begin
-    outputs.op_ld_a_rr_sx01 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "00--1010" and state ?= "-01";
+    outputs.op_ld_a_rr_sx01 <= clk and not intr and not cb_mode and ir_reg ?= "00--1010" and state ?= "-01";
   end process;
 
   col_28: process(all)
   begin
-    outputs.cb_bit <= clk and not intr_dispatch and cb_mode and ir_reg ?= "01------" and state ?= "---";
+    outputs.cb_bit <= clk and not intr and cb_mode and ir_reg ?= "01------" and state ?= "---";
   end process;
 
   col_29_to_30: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 4) ?= "00--";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 4) ?= "00--";
     outputs.op_ld_rr_a_sx00 <= t and ir_reg(3 downto 0) ?= "0010" and state ?= "-00";
     outputs.op_ld_a_rr_sx00 <= t and ir_reg(3 downto 0) ?= "1010" and state ?= "-00";
   end process;
@@ -157,7 +157,7 @@ begin
   col_31_to_33: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 2) ?= "111000";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 2) ?= "111000";
     outputs.op_ldh_c_a_sx00 <= t and ir_reg(1 downto 0) ?= "10" and state ?= "-00";
     outputs.op_ldh_n_a_sx00 <= t and ir_reg(1 downto 0) ?= "00" and state ?= "-00";
     outputs.op_ldh_n_a_sx01 <= t and ir_reg(1 downto 0) ?= "00" and state ?= "-01";
@@ -166,7 +166,7 @@ begin
   col_34: process(all)
     variable t, s1, c2, c3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 7) ?= "0";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 7) ?= "0";
     s1 := t and ir_reg(6 downto 3) ?= "10--";
     c2 := t and ir_reg(6 downto 3) ?= "1-0-";
     c3 := t and ir_reg(6 downto 3) ?= "1--1";
@@ -175,13 +175,13 @@ begin
 
   col_35: process(all)
   begin
-    outputs.op_alu_misc_s0xx <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "00---111" and state ?= "0--";
+    outputs.op_alu_misc_s0xx <= clk and not intr and not cb_mode and ir_reg ?= "00---111" and state ?= "0--";
   end process;
 
   col_36_to_38: process(all)
     variable t, l: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 4) ?= "00--";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 4) ?= "00--";
     l := t and ir_reg(3 downto 2) ?= "10";
     outputs.op_add_hl_sxx0 <= l and ir_reg(1 downto 0) ?= "01" and state ?= "--0";
     outputs.op_dec_rr_sx00 <= l and ir_reg(1 downto 0) ?= "11" and state ?= "-00";
@@ -191,7 +191,7 @@ begin
   col_39_to_40: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "11--0101";
+    t := clk and not intr and not cb_mode and ir_reg ?= "11--0101";
     outputs.op_push_sx01 <= t and state ?= "-01";
     outputs.op_push_sx00 <= t and state ?= "-00";
   end process;
@@ -199,7 +199,7 @@ begin
   col_41: process(all)
     variable t, u1, u2, u3, l1, l2, l3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "01";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "01";
     u1 := t and ir_reg(5 downto 3) ?= "0--";
     u2 := t and ir_reg(5 downto 3) ?= "-0-";
     u3 := t and ir_reg(5 downto 3) ?= "--1";
@@ -211,18 +211,18 @@ begin
 
   col_42: process(all)
   begin
-    outputs.op_40_to_7f <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "01------" and state ?= "---";
+    outputs.op_40_to_7f <= clk and not intr and not cb_mode and ir_reg ?= "01------" and state ?= "---";
   end process;
 
   col_43: process(all)
   begin
-    outputs.cb_00_to_3f <= clk and not intr_dispatch and cb_mode and ir_reg ?= "00------" and state ?= "---";
+    outputs.cb_00_to_3f <= clk and not intr and cb_mode and ir_reg ?= "00------" and state ?= "---";
   end process;
 
   col_44_to_46: process(all)
     variable t, l, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 5) ?= "110";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 5) ?= "110";
     l := t and ir_reg(4 downto 0) ?= "0001-";
     r := t and ir_reg(4 downto 0) ?= "--010";
     outputs.op_jp_any_sx00 <= (l or r) and state ?= "-00";
@@ -233,7 +233,7 @@ begin
   col_47_to_48: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "00";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "00";
     outputs.op_add_hl_sx01 <= t and ir_reg(5 downto 0) ?= "--1001" and state ?= "-01";
     outputs.op_ld_hl_n_sx01 <= t and ir_reg(5 downto 0) ?= "110110" and state ?= "-01";
   end process;
@@ -243,7 +243,7 @@ begin
   col_51_to_53: process(all)
     variable t, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 3) ?= "11--0";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 3) ?= "11--0";
     r := t and ir_reg(2 downto 0) ?= "001" and state(2 downto 1) ?= "-0";
     outputs.op_push_sx10 <= t and ir_reg(2 downto 0) ?= "101" and state ?= "-10";
     outputs.op_pop_sx00 <= r and state(0 downto 0) ?= "0";
@@ -252,18 +252,18 @@ begin
 
   col_54: process(all)
   begin
-    outputs.op_add_sp_s001 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11101000" and state ?= "001";
+    outputs.op_add_sp_s001 <= clk and not intr and not cb_mode and ir_reg ?= "11101000" and state ?= "001";
   end process;
 
   col_55: process(all)
   begin
-    outputs.op_ld_hl_sp_sx01 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11111000" and state ?= "-01";
+    outputs.op_ld_hl_sp_sx01 <= clk and not intr and not cb_mode and ir_reg ?= "11111000" and state ?= "-01";
   end process;
 
   col_56: process(all)
     variable t, l1, l2, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and cb_mode and ir_reg(7 downto 4) ?= "11--";
+    t := clk and not intr and cb_mode and ir_reg(7 downto 4) ?= "11--";
     l1 := t and ir_reg(3 downto 0) ?= "-0--";
     l2 := t and ir_reg(3 downto 0) ?= "--0-";
     r := t and ir_reg(3 downto 0) ?= "---1";
@@ -273,25 +273,25 @@ begin
   col_57_to_58: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and cb_mode and ir_reg(7 downto 7) ?= "1";
+    t := clk and not intr and cb_mode and ir_reg(7 downto 7) ?= "1";
     outputs.cb_set_hl_sx01 <= t and ir_reg(6 downto 0) ?= "1---110" and state ?= "-01";
     outputs.cb_set_res_hl_sx00 <= t and ir_reg(6 downto 0) ?= "----110" and state ?= "-00";
   end process;
 
   col_59: process(all)
   begin
-    outputs.op_pop_sx10 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11--0001" and state ?= "-10";
+    outputs.op_pop_sx10 <= clk and not intr and not cb_mode and ir_reg ?= "11--0001" and state ?= "-10";
   end process;
 
   col_60: process(all)
   begin
-    outputs.op_ldh_a_n_sx01 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11110000" and state ?= "-01";
+    outputs.op_ldh_a_n_sx01 <= clk and not intr and not cb_mode and ir_reg ?= "11110000" and state ?= "-01";
   end process;
 
   col_61_to_62: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "00001000";
+    t := clk and not intr and not cb_mode and ir_reg ?= "00001000";
     outputs.op_ld_nn_sp_s010 <= t and state ?= "010";
     outputs.op_ld_nn_sp_s000 <= t and state ?= "000";
   end process;
@@ -299,7 +299,7 @@ begin
   col_63_to_66: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "11";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "11";
     outputs.op_ld_sp_hl_sx00 <= t and ir_reg(5 downto 0) ?= "111001" and state ?= "-00";
     outputs.op_add_sp_e_s000 <= t and ir_reg(5 downto 0) ?= "101000" and state ?= "000";
     outputs.op_add_sp_e_s011 <= t and ir_reg(5 downto 0) ?= "101000" and state ?= "011";
@@ -309,7 +309,7 @@ begin
   col_67_to_68: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "00001000" and state(2 downto 2) ?= "0";
+    t := clk and not intr and not cb_mode and ir_reg ?= "00001000" and state(2 downto 2) ?= "0";
     outputs.op_ld_nn_sp_s011 <= t and state(1 downto 0) ?= "11";
     outputs.op_ld_nn_sp_s001 <= t and state(1 downto 0) ?= "01";
   end process;
@@ -317,7 +317,7 @@ begin
   col_69: process(all)
     variable t, s1, c2, c3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 3) ?= "01110";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 3) ?= "01110";
     s1 := t and ir_reg(2 downto 0) ?= "--1";
     c2 := t and ir_reg(2 downto 0) ?= "-0-";
     c3 := t and ir_reg(2 downto 0) ?= "0--";
@@ -327,7 +327,7 @@ begin
   col_70_to_71: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "0011010-";
+    t := clk and not intr and not cb_mode and ir_reg ?= "0011010-";
     outputs.op_incdec8_hl_sx00 <= t and state ?= "-00";
     outputs.op_incdec8_hl_sx01 <= t and state ?= "-01";
   end process;
@@ -335,7 +335,7 @@ begin
   col_72_to_73: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 2) ?= "111100";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 2) ?= "111100";
     outputs.op_ldh_a_c_sx00 <= t and ir_reg(1 downto 0) ?= "10" and state ?= "-00";
     outputs.op_ldh_a_n_sx00 <= t and ir_reg(1 downto 0) ?= "00" and state ?= "-00";
   end process;
@@ -343,7 +343,7 @@ begin
   col_74_to_75: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "11---111" and state(2 downto 2) ?= "-";
+    t := clk and not intr and not cb_mode and ir_reg ?= "11---111" and state(2 downto 2) ?= "-";
     outputs.op_rst_sx01 <= t and state(1 downto 0) ?= "01";
     outputs.op_rst_sx00 <= t and state(1 downto 0) ?= "00";
   end process;
@@ -351,7 +351,7 @@ begin
   col_76_to_78: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and intr_dispatch and not cb_mode and ir_reg ?= "--------";
+    t := clk and intr and not cb_mode and ir_reg ?= "--------";
     outputs.int_s101 <= t and state ?= "101";
     outputs.int_s100 <= t and state ?= "100";
     outputs.int_s000 <= t and state ?= "000";
@@ -360,7 +360,7 @@ begin
   col_79: process(all)
     variable t, s1, c2, c3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 3) ?= "10---";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 3) ?= "10---";
     s1 := t and ir_reg(2 downto 0) ?= "-0-";
     c2 := t and ir_reg(2 downto 0) ?= "0--";
     c3 := t and ir_reg(2 downto 0) ?= "--1";
@@ -370,20 +370,20 @@ begin
   col_80_to_81: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 4) ?= "110-";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 4) ?= "110-";
     outputs.op_ret_reti_sx00 <= t and ir_reg(3 downto 0) ?= "1001" and state ?= "-00";
     outputs.op_ret_cc_sx01 <= t and ir_reg(3 downto 0) ?= "-000" and state ?= "-01";
   end process;
 
   col_82: process(all)
   begin
-    outputs.op_jp_hl_s0xx <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11101001" and state ?= "0--";
+    outputs.op_jp_hl_s0xx <= clk and not intr and not cb_mode and ir_reg ?= "11101001" and state ?= "0--";
   end process;
 
   col_83_to_84: process(all)
     variable t, s1, c2: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 4) ?= "110-";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 4) ?= "110-";
     s1 := t and ir_reg(3 downto 0) ?= "100-";
     c2 := t and ir_reg(3 downto 0) ?= "-000";
     outputs.op_ret_any_reti_s010 <= (s1 or c2) and state ?= "010";
@@ -393,7 +393,7 @@ begin
   col_85_to_86: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "00";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "00";
     outputs.op_ld_hlinc_sx00 <= t and ir_reg(5 downto 0) ?= "10-010" and state ?= "-00";
     outputs.op_ld_hldec_sx00 <= t and ir_reg(5 downto 0) ?= "11-010" and state ?= "-00";
   end process;
@@ -401,7 +401,7 @@ begin
   col_87_to_89: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "00--0001";
+    t := clk and not intr and not cb_mode and ir_reg ?= "00--0001";
     outputs.op_ld_rr_sx00 <= t and state ?= "-00";
     outputs.op_ld_rr_sx01 <= t and state ?= "-01";
     outputs.op_ld_rr_sx10 <= t and state ?= "-10";
@@ -410,7 +410,7 @@ begin
   col_90: process(all)
     variable t, s1, c2, c3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "00";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "00";
     s1 := t and ir_reg(5 downto 3) ?= "--1";
     c2 := t and ir_reg(5 downto 3) ?= "-0-";
     c3 := t and ir_reg(5 downto 3) ?= "0--";
@@ -419,28 +419,28 @@ begin
 
   col_91: process(all)
   begin
-    outputs.op_alu_hl_sx00 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "10---110" and state ?= "-00";
+    outputs.op_alu_hl_sx00 <= clk and not intr and not cb_mode and ir_reg ?= "10---110" and state ?= "-00";
   end process;
 
   col_92: process(all)
   begin
-    outputs.op_alu_n_sx00 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11---110" and state ?= "-00";
+    outputs.op_alu_n_sx00 <= clk and not intr and not cb_mode and ir_reg ?= "11---110" and state ?= "-00";
   end process;
 
   col_93: process(all)
   begin
-    outputs.op_rst_sx10 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11---111" and state ?= "-10";
+    outputs.op_rst_sx10 <= clk and not intr and not cb_mode and ir_reg ?= "11---111" and state ?= "-10";
   end process;
 
   col_94: process(all)
   begin
-    outputs.int_s110 <= clk and intr_dispatch and not cb_mode and ir_reg ?= "--------" and state ?= "110";
+    outputs.int_s110 <= clk and intr and not cb_mode and ir_reg ?= "--------" and state ?= "110";
   end process;
 
   col_95: process(all)
     variable t, s1, c2, c3: std_ulogic;
   begin
-    t := clk and not intr_dispatch and cb_mode and ir_reg(7 downto 3) ?= "-----";
+    t := clk and not intr and cb_mode and ir_reg(7 downto 3) ?= "-----";
     s1 := t and ir_reg(2 downto 0) ?= "--1";
     c2 := t and ir_reg(2 downto 0) ?= "0--";
     c3 := t and ir_reg(2 downto 0) ?= "-0-";
@@ -449,48 +449,48 @@ begin
 
   col_96: process(all)
   begin
-    outputs.cb_hl_sx00 <= clk and not intr_dispatch and cb_mode and ir_reg ?= "-----110" and state ?= "-00";
+    outputs.cb_hl_sx00 <= clk and not intr and cb_mode and ir_reg ?= "-----110" and state ?= "-00";
   end process;
 
   col_97: process(all)
   begin
-    outputs.cb_bit_hl_sx01 <= clk and not intr_dispatch and cb_mode and ir_reg ?= "01---110" and state ?= "-01";
+    outputs.cb_bit_hl_sx01 <= clk and not intr and cb_mode and ir_reg ?= "01---110" and state ?= "-01";
   end process;
 
   col_98: process(all)
   begin
-    outputs.cb_notbit_hl_sx01 <= clk and not intr_dispatch and cb_mode and ir_reg ?= "-0---110" and state ?= "-01";
+    outputs.cb_notbit_hl_sx01 <= clk and not intr and cb_mode and ir_reg ?= "-0---110" and state ?= "-01";
   end process;
 
   col_99: process(all)
   begin
-    outputs.op_incdec8 <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "00---10-" and state ?= "---";
+    outputs.op_incdec8 <= clk and not intr and not cb_mode and ir_reg ?= "00---10-" and state ?= "---";
   end process;
 
   col_100: process(all)
   begin
-    outputs.op_di_ei_s0xx <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "1111-011" and state ?= "0--";
+    outputs.op_di_ei_s0xx <= clk and not intr and not cb_mode and ir_reg ?= "1111-011" and state ?= "0--";
   end process;
 
   col_101: process(all)
   begin
-    outputs.op_halt_s0xx <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "01110110" and state ?= "0--";
+    outputs.op_halt_s0xx <= clk and not intr and not cb_mode and ir_reg ?= "01110110" and state ?= "0--";
   end process;
 
   col_102: process(all)
   begin
-    outputs.op_nop_stop_s0xx <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "000-0000" and state ?= "0--";
+    outputs.op_nop_stop_s0xx <= clk and not intr and not cb_mode and ir_reg ?= "000-0000" and state ?= "0--";
   end process;
 
   col_103: process(all)
   begin
-    outputs.op_cb_s0xx <= clk and not intr_dispatch and not cb_mode and ir_reg ?= "11001011" and state ?= "0--";
+    outputs.op_cb_s0xx <= clk and not intr and not cb_mode and ir_reg ?= "11001011" and state ?= "0--";
   end process;
 
   col_104: process(all)
     variable t, l, r: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg(7 downto 6) ?= "00";
+    t := clk and not intr and not cb_mode and ir_reg(7 downto 6) ?= "00";
     l := t and ir_reg(5 downto 0) ?= "011000";
     r := t and ir_reg(5 downto 0) ?= "1--000";
     outputs.op_jr_any_sx10 <= (l or r) and state ?= "-10";
@@ -499,7 +499,7 @@ begin
   col_105_to_106: process(all)
     variable t: std_ulogic;
   begin
-    t := clk and not intr_dispatch and not cb_mode and ir_reg ?= "111-1010";
+    t := clk and not intr and not cb_mode and ir_reg ?= "111-1010";
     outputs.op_ea_fa_s000 <= t and state ?= "000";
     outputs.op_ea_fa_s001 <= t and state ?= "001";
   end process;

--- a/sm83-cpu-core/hdl/interrupts.vhd
+++ b/sm83-cpu-core/hdl/interrupts.vhd
@@ -17,12 +17,12 @@ entity interrupts is
     wr: in std_ulogic;
     rd: in std_ulogic;
     irq: in std_ulogic_vector(7 downto 0);
-    nmi_trigger: in std_ulogic;
+    nmi_dispatch: in std_ulogic;
     int_s110: in std_ulogic;
     intr_addr: out std_ulogic_vector(7 downto 3);
+    intr_wake: out std_ulogic;
     irq_ack: out std_ulogic_vector(7 downto 0);
-    irq_trigger: out std_ulogic;
-    intr_trigger: out std_ulogic
+    irq_req: out std_ulogic
   );
 end entity;
 
@@ -52,14 +52,14 @@ begin
     data(i) <= '0' when not ie_reg(i) and addr_ffff and rd else 'Z';
   end generate;
 
-  intr_trigger <= (or irq_latch) or nmi_trigger;
+  intr_wake <= (or irq_latch) or nmi_dispatch;
   irq_ack <= irq_prio and int_s110;
 
   intr_addr(3) <= writeback and (irq_ack(1) or irq_ack(3) or irq_ack(5) or irq_ack(7));
   intr_addr(4) <= writeback and (irq_ack(2) or irq_ack(3) or irq_ack(6) or irq_ack(7));
   intr_addr(5) <= writeback and (irq_ack(4) or irq_ack(6) or irq_ack(7));
-  intr_addr(6) <= int_s110 and irq_trigger;
-  intr_addr(7) <= int_s110 and nmi_trigger;
+  intr_addr(6) <= int_s110 and irq_req;
+  intr_addr(7) <= int_s110 and nmi_dispatch;
 
   irq_latch_gen: for i in 0 to 7 generate
     irq_latch_inst: entity work.dlatch
@@ -70,14 +70,14 @@ begin
     );
   end generate;
 
-  irq_prio(0) <= '1' when irq_latch ?= "-------1" and not nmi_trigger else '0';
-  irq_prio(1) <= '1' when irq_latch ?= "------10" and not nmi_trigger else '0';
-  irq_prio(2) <= '1' when irq_latch ?= "-----100" and not nmi_trigger else '0';
-  irq_prio(3) <= '1' when irq_latch ?= "----1000" and not nmi_trigger else '0';
-  irq_prio(4) <= '1' when irq_latch ?= "---10000" and not nmi_trigger else '0';
-  irq_prio(5) <= '1' when irq_latch ?= "--100000" and not nmi_trigger else '0';
-  irq_prio(6) <= '1' when irq_latch ?= "-1000000" and not nmi_trigger else '0';
-  irq_prio(7) <= '1' when irq_latch ?= "10000000" and not nmi_trigger else '0';
+  irq_prio(0) <= '1' when irq_latch ?= "-------1" and not nmi_dispatch else '0';
+  irq_prio(1) <= '1' when irq_latch ?= "------10" and not nmi_dispatch else '0';
+  irq_prio(2) <= '1' when irq_latch ?= "-----100" and not nmi_dispatch else '0';
+  irq_prio(3) <= '1' when irq_latch ?= "----1000" and not nmi_dispatch else '0';
+  irq_prio(4) <= '1' when irq_latch ?= "---10000" and not nmi_dispatch else '0';
+  irq_prio(5) <= '1' when irq_latch ?= "--100000" and not nmi_dispatch else '0';
+  irq_prio(6) <= '1' when irq_latch ?= "-1000000" and not nmi_dispatch else '0';
+  irq_prio(7) <= '1' when irq_latch ?= "10000000" and not nmi_dispatch else '0';
 
-  irq_trigger <= or(irq_prio) and writeback;
+  irq_req <= or(irq_prio) and writeback;
 end architecture;

--- a/sm83-cpu-core/hdl/interrupts.vhd
+++ b/sm83-cpu-core/hdl/interrupts.vhd
@@ -58,7 +58,7 @@ begin
   intr_addr(3) <= writeback and (irq_ack(1) or irq_ack(3) or irq_ack(5) or irq_ack(7));
   intr_addr(4) <= writeback and (irq_ack(2) or irq_ack(3) or irq_ack(6) or irq_ack(7));
   intr_addr(5) <= writeback and (irq_ack(4) or irq_ack(6) or irq_ack(7));
-  intr_addr(6) <= int_s110 and intr_trigger;
+  intr_addr(6) <= int_s110 and irq_trigger;
   intr_addr(7) <= int_s110 and nmi_trigger;
 
   irq_latch_gen: for i in 0 to 7 generate


### PR DESCRIPTION
After playing around locally with the NMI machinery, I've assigned more meaningful names to all of the control unit signals and organized them into sections.  Also, a typo became apparent in the interrupt address calculation code -- before this change, simulating an NMI would dispatch to 0x00C0, rather than the correct 0x0080 (per Sharp 1996 Databook docs and descriptions of an unreleased GBC palette-switching feature).